### PR TITLE
Add redirect for unauthenticated users

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,9 +1,20 @@
-import { Tabs } from 'expo-router';
+import { Tabs, Redirect } from 'expo-router';
 import { View, StyleSheet, Image } from 'react-native';
 import { Chrome as Home, SquareCheck as CheckSquare, Award, TrendingUp, User, MessageCircle, Shield } from 'lucide-react-native';
 import { colors } from '@/constants/colors';
+import { useAuth } from '@/hooks/useAuth';
 
 export default function TabLayout() {
+  const { session, loading } = useAuth();
+
+  if (loading) {
+    return null;
+  }
+
+  if (!session) {
+    return <Redirect href="/sign-in" />;
+  }
+
   return (
     <Tabs
       screenOptions={{


### PR DESCRIPTION
## Summary
- ensure unauthenticated users visiting the app are sent to the sign-in screen

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6841de5aad508328b97009b93ed46fa1