### PR TITLE
Add logo to auth pages

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -46,13 +46,13 @@ export default function SignInScreen() {
         end={{ x: 1, y: 0 }}
       />
       
+      <Image
+        source={require('@/assets/images/logo.png')}
+        style={styles.logo}
+        resizeMode="contain"
+      />
       <View style={styles.content}>
         <View style={styles.header}>
-          <Image
-            source={require('@/assets/images/logo.png')}
-            style={styles.logo}
-            resizeMode="contain"
-          />
           <Text style={styles.title}>Bine ai revenit!</Text>
           <Text style={styles.subtitle}>Conectează-te pentru a continua</Text>
         </View>
@@ -146,7 +146,9 @@ const styles = StyleSheet.create({
   logo: {
     width: 200,
     height: 80,
+    marginTop: 60,
     marginBottom: 24,
+    alignSelf: 'center',
   },
   title: {
     fontFamily: 'Nunito-Bold',

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -75,6 +75,11 @@ export default function SignUpScreen() {
           style={styles.headerImage}
         />
         <View style={styles.overlay} />
+        <Image
+          source={require('@/assets/images/logo.png')}
+          style={styles.logo}
+          resizeMode="contain"
+        />
         <Text style={styles.title}>Creează-ți cont</Text>
         <Text style={styles.subtitle}>Alătură-te familiei FamSync</Text>
       </View>
@@ -186,6 +191,13 @@ const styles = StyleSheet.create({
   overlay: {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(79, 124, 172, 0.8)',
+  },
+  logo: {
+    width: 200,
+    height: 80,
+    position: 'absolute',
+    top: 40,
+    alignSelf: 'center',
   },
   title: {
     fontFamily: 'Nunito-Bold',


### PR DESCRIPTION
## Summary
- show `logo.png` at the top of sign-in screen
- add the logo overlay to the sign-up header

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_b_6841e23a9968832880b1f21438412ae8