### PR TITLE
Fix logo position on auth screens

### DIFF
--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -20,12 +20,14 @@ export default function AuthLayout() {
         name="sign-in"
         options={{
           title: 'Conectare',
+          headerShown: false,
         }}
       />
       <Stack.Screen
         name="sign-up"
         options={{
           title: 'Înregistrare',
+          headerShown: false,
         }}
       />
       <Stack.Screen

--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -138,6 +138,7 @@ const styles = StyleSheet.create({
   content: {
     flex: 1,
     justifyContent: 'center',
+    paddingTop: 140,
   },
   header: {
     alignItems: 'center',
@@ -146,8 +147,8 @@ const styles = StyleSheet.create({
   logo: {
     width: 200,
     height: 80,
-    marginTop: 60,
-    marginBottom: 24,
+    position: 'absolute',
+    top: 40,
     alignSelf: 'center',
   },
   title: {


### PR DESCRIPTION
## Summary
- hide default headers on `sign-in` and `sign-up`
- absolutely position the logo on the sign-in page and shift content downward

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'expo-router')*

------
https://chatgpt.com/codex/tasks/task_b_6841e39a7b448328ac71999b36cd2d3e