### PR TITLE
Display app logo on sign-in screen

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -6,7 +6,6 @@ import { colors } from '@/constants/colors';
 import { supabase } from '@/lib/supabase';
 import { LinearGradient } from 'expo-linear-gradient';
 
-import logo from '../../assets/images/logo.png';
 
 export default function SignInScreen() {
   const [email, setEmail] = useState('');
@@ -47,7 +46,7 @@ export default function SignInScreen() {
       end={{ x: 1, y: 0 }}
     >
       <Image
-        source={logo}
+        source={require('@/assets/images/logo.png')}
         style={styles.logo}
         resizeMode="contain"
       />


### PR DESCRIPTION
## Summary
- reference the logo directly on the sign-in screen

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_684827fda3908328861ae2aa10a4c0ef